### PR TITLE
Rearrange history on paste

### DIFF
--- a/lib/clipboard-history-view.coffee
+++ b/lib/clipboard-history-view.coffee
@@ -85,6 +85,7 @@ class ClipboardHistoryView extends SelectListView
     else
       @history.splice(@history.indexOf(item), 1)
       @history.push(item)
+      atom.clipboard.write(item.text)
       atom.workspaceView.getActivePaneItem().insertText item.text,
         select: true
     @cancel()


### PR DESCRIPTION
This atom plug-in is perfect...simple, and does exactly what it should.

I'm accustomed to the behavior in Sublime's Clipboard Manager and Visual SlickEdit's clipboard manager though, which modifies the history order when you paste from the selection window.

This change puts the selected item on the top of the history, then copies the text of the item into the atom clipboard so you can paste the text over and over without having to select it again.

Perhaps this change is useful.
